### PR TITLE
Restore conversation ui elements

### DIFF
--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ async function postToEndpoint(endpoint, payload, timeoutMs = 45000) {
 
 document.addEventListener("DOMContentLoaded", () => {
   historyBox.value = localStorage.getItem("chatHistory") || "";
-  historyBox.style.display = "none";
+  historyBox.style.display = "block";
 
   inputBox.addEventListener("keydown", (e) => {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -118,9 +118,8 @@ async function sendMessage() {
 
 function toggleHistory() {
   const btn = document.getElementById("toggleHistoryBtn");
-  const isHidden = historyBox.style.display === "none";
-  historyBox.style.display = isHidden ? "block" : "none";
-  if (btn) btn.textContent = isHidden ? "Ocultar historial" : "Mostrar historial";
+  historyBox.style.display = "block";
+  if (btn) btn.textContent = "Ocultar historial";
 }
 
 window.sendMessage = sendMessage;

--- a/styles.css
+++ b/styles.css
@@ -51,7 +51,7 @@ textarea {
 #historyBox {
   margin-top: 0.5em;
   width: 100%;
-  display: none;
+  display: block;
   border: 1px solid #e0e0e0;
   border-radius: 0;
 }


### PR DESCRIPTION
Make the chat history box always visible and remove its toggle functionality to ensure it remains available within conversations.

---
<a href="https://cursor.com/background-agent?bcId=bc-6791a551-18f8-44b0-89de-a4d3806fb1f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6791a551-18f8-44b0-89de-a4d3806fb1f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

